### PR TITLE
Make license-ls compatible with npm 7.x

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,3 +59,7 @@ lib(options)
         spinner.succeed()
         console.log(output)
     })
+    .catch(reason => {
+        spinner.fail('Unexpected error')
+        console.error(reason);
+    })

--- a/helpers/npm-list.js
+++ b/helpers/npm-list.js
@@ -11,7 +11,7 @@ const optionsToArgv = require('./options-to-args')
  * @returns {Promise<Array<Object>>}
  */
 module.exports = function (opts = {}) {
-    const blackListOpts = ['format']
+    const blackListOpts = ['format', 'csv']
     const options = optionsToArgv(opts, blackListOpts)
     
     return new Promise((resolve, reject) => {

--- a/lib.js
+++ b/lib.js
@@ -12,7 +12,7 @@ const glob = promisify(require('glob'))
  */
 module.exports = async function (options = {}) {
     const pathList = await npmLs(options)
-    return  await Promise.all(pathList.map(async (path, index) => {
+    return Promise.all(pathList.map(async (path, index) => {
         const pkg = await getPackageDetails(path)
         const licShortName = extractLicenseText(pkg.license || pkg.licenses || pkg.licence || pkg.licences)
         const licLongName = getExpandedLicName(licShortName) || 'unknown'

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,7 +1,20 @@
-const cli = require('../cli')
 const test = require('ava')
+const spawn = require("cross-spawn");
 
-test('Does the thing', async (t) => {
-    // TODO: how do I test this since it's not a function?
-    t.true(true)
+test('runs successfully', async (t) => {
+    t.timeout(10000)
+    const args = [
+        'cli.js',
+        '--format=json',
+        '--depth=0',
+        '--prod',
+    ]
+
+    const sync = spawn.sync('node', args, {encoding: 'utf-8'})
+
+    t.regex(sync.stderr, /^- Analyzing\n(√|✔) Analyzing\n- Building output format\n(√|✔) Building output format\n$/)
+    t.is(sync.status, 0)
+
+    const output = JSON.parse(sync.stdout)
+    t.is(output.length, 12, 'number of packages in the output should match the direct dependencies of license-ls')
 })

--- a/tests/npm-ls.test.js
+++ b/tests/npm-ls.test.js
@@ -1,5 +1,6 @@
 const npmList = require('../helpers/npm-list')
 const test = require('ava')
+const fs = require('fs')
 
 test('Returns a non-empty array of package paths', async (t) => {
     const actual = await npmList()
@@ -30,5 +31,23 @@ test('Produces different results when given different options', async (t) => {
 
     t.true(prodOnly.length > devOnly.length)
     t.notDeepEqual(prodOnly, devOnly)
+})
+
+test('Handles more complex options correctly', async (t) => {
+    const opts = {
+        csv: { delimiter: ',' },
+        depth: 0,
+        format: 'json',
+        prod: true,
+        production: true,
+        include: [ 'id', 'name', 'version', 'license', 'repository', 'author', 'homepage', 'dependencyLevel' ],
+        table: {},
+        xml: { asAttrs: false, 'as-attrs': false }
+    }
+
+    const actual = await npmList(opts);
+
+    t.true(actual.length > 0)
+    actual.forEach(path => t.true(fs.existsSync('' + path), `invalid path: ${path}`))
 })
 


### PR DESCRIPTION
This fixes issue #20
 
* do not pass --csv-option to npm list and make license-ls compatible with npm 7.x
* handle errors and stop the spinner so that the program terminates
* small refactorings